### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🎯 SkillsForge Marketplace
 
+[![Run in Smithery](https://smithery.ai/badge/skills/rawveg)](https://smithery.ai/skills?ns=rawveg&utm_source=github&utm_medium=badge)
+
+
 > A curated collection of Claude Code skills and plugins to supercharge your development workflow
 
 Welcome to SkillsForge! This marketplace provides a centralized hub for discovering and installing powerful Claude Code extensions that enhance your productivity, streamline your workflows, and integrate with your favorite tools and services.


### PR DESCRIPTION
## Add skill discoverability badge

Your 31 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/rawveg)](https://smithery.ai/skills?ns=rawveg&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.