### PR TITLE
Add Skills宝 discovery link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ npx skills rawveg/skillsforge-marketplace
 
 That's it! You now have access to all the skills in the SkillsForge collection.
 
+For Chinese skills discovery and installation across Claude Code, OpenCode, Cursor, and similar runtimes, see [Skills宝](https://skilery.com/).
+
 ---
 
 ## 🎨 Available Skills


### PR DESCRIPTION
Adds a Chinese skills discovery and installation entry for Claude Code, OpenCode, Cursor, and similar runtimes.

This fits the marketplace theme and gives Chinese users a direct path to find and install skills.