### PR TITLE
feat: add NotFair - SEO, Google Ads & Meta Ads skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,6 +160,15 @@
       ]
     },
     {
+      "name": "notfair-marketing",
+      "description": "SEO, Google Ads, and Meta Ads skills for Claude Code, powered by Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./notfair-marketing"
+      ]
+    },
+    {
       "name": "ollama",
       "description": "Interacts with the Ollama API.",
       "source": "./",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ That's it! You now have access to all the skills in the SkillsForge collection.
 
 ## 🎨 Available Skills
 
-SkillsForge currently offers **33 curated skills** and **1 hooks plugin** across focused categories. Only items included in `.claude-plugin/marketplace.json` are listed below.
+SkillsForge currently offers **34 curated skills** and **1 hooks plugin** across focused categories. Only items included in `.claude-plugin/marketplace.json` are listed below.
 
 ### 📝 Content & Publishing
 
@@ -55,6 +55,12 @@ SkillsForge currently offers **33 curated skills** and **1 hooks plugin** across
 | **[tumblr](./tumblr)** | Manage articles and profile on Tumblr. |
 | **[word-count-checker](./word-count-checker)** | Accurately count words in documents (avoids token-based estimates). |
 | **[writeas](./writeas)** | Work with Write.as/WriteFreely for simple publishing. |
+
+### 📣 Marketing & Advertising
+
+| Skill | Purpose |
+|-------|---------|
+| **[notfair-marketing](./notfair-marketing)** | SEO, Google Ads, and Meta Ads skills connecting to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. |
 
 ### 🛠️ Development Tools
 

--- a/notfair-marketing/SKILL.md
+++ b/notfair-marketing/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: notfair-marketing
+description: Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live account data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to run audits, keyword research, meta tag generation, schema markup, wasted-spend detection, and ad creative analysis directly inside Claude Code.
+---
+
+# NotFair Marketing Skills
+
+## Overview
+
+NotFair is a collection of open-source Claude Code skills covering three marketing domains:
+
+- **SEO** — site analysis, keyword research, meta tag optimization, schema markup generation, GEO (generative engine optimization), and content writing.
+- **Google Ads** — account audits, wasted-spend detection, search-term cleanup, keyword management, and bid analysis.
+- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap identification, and campaign health checks.
+
+All skills connect to live data through MCP servers: Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+
+Source: [github.com/nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)
+
+## Requirements
+
+- Claude Code with MCP support
+- One or more of the following MCP servers configured, depending on which skills you use:
+  - [Google Ads MCP](https://github.com/nowork-studio/NotFair) for Google Ads skills
+  - [Meta Ads MCP](https://github.com/nowork-studio/NotFair) for Meta Ads skills
+  - [Google Search Console MCP](https://github.com/nowork-studio/NotFair) for SEO skills
+  - [Google Analytics (GA4) MCP](https://github.com/nowork-studio/NotFair) for analytics-backed SEO skills
+
+## Skill Areas
+
+### SEO (`seo/`)
+
+| Skill | What it does |
+|-------|-------------|
+| `seo-audit` | Full site SEO audit using Search Console and GA4 data |
+| `keyword-research` | Keyword opportunity research with volume and intent analysis |
+| `meta-tags-optimizer` | Generate optimized title and description tags |
+| `schema-markup-generator` | Create structured data markup for rich results |
+| `geo-optimizer` | Optimize content for AI-powered search (GEO) |
+| `content-writer` | Write SEO-optimized content briefs and drafts |
+
+### Google Ads (`google-ads/`)
+
+| Skill | What it does |
+|-------|-------------|
+| `google-ads-audit` | Full account audit: spend, quality scores, and performance trends |
+| `google-ads` | General Google Ads management tasks |
+| `google-ads-copy` | Generate and review ad copy |
+| `google-ads-landing` | Audit landing page relevance vs. ad copy |
+
+### Meta Ads (`meta-ads/`)
+
+| Skill | What it does |
+|-------|-------------|
+| `meta-ads-audit` | Full Meta Ads account audit: ROAS, creative fatigue, audience overlap |
+| `meta-ads` | General Meta Ads management tasks |
+
+## Installation
+
+```bash
+# Install from the SkillsForge marketplace
+/plugin install notfair-marketing@skillsforge-marketplace
+```
+
+Or install directly from the source repository:
+
+```bash
+/plugin install github:nowork-studio/NotFair
+```
+
+## License
+
+MIT — see [github.com/nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) for details.

--- a/notfair-marketing/plugin.json
+++ b/notfair-marketing/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "notfair-marketing",
+  "description": "SEO, Google Ads, and Meta Ads skills for Claude Code, powered by Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.",
+  "version": "1.0.0",
+  "author": {
+    "name": "nowork-studio",
+    "url": "https://github.com/nowork-studio/NotFair"
+  },
+  "homepage": "https://github.com/nowork-studio/NotFair",
+  "repository": "https://github.com/nowork-studio/NotFair",
+  "license": "MIT",
+  "keywords": ["SEO", "Google Ads", "Meta Ads", "marketing", "Claude Code", "MCP"],
+  "category": "marketing",
+  "strict": false
+}


### PR DESCRIPTION
Hi Tim,

Thanks for building SkillsForge — it is a great home for Claude Code skills.

This PR adds **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source collection of Claude Code skills for marketing work (~2.9k stars, MIT license). It covers three areas:

- **SEO** — site audits, keyword research, meta tag optimization, schema markup, GEO optimization, and content writing
- **Google Ads** — account audits, wasted-spend detection, search-term cleanup, keyword and bid management
- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap

What makes it distinct is that it connects to live account data through four MCP servers: Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so Claude can pull real performance data rather than working from static inputs.

I have added it in a new "Marketing & Advertising" section in the README, added a `notfair-marketing/` skill directory with `SKILL.md` and `plugin.json`, and registered it in `marketplace.json`.

Happy to reword the description, move it to a different section, or trim anything that does not fit your style. Let me know what works best.

Thanks again!